### PR TITLE
Use the full display frame for the overlay

### DIFF
--- a/MOTION.md
+++ b/MOTION.md
@@ -53,4 +53,4 @@ These checks do not measure physical end-to-end latency, which also depends on t
 
 ## Recovery
 
-Sensor loss cancels both startup and active capture. Switching Spaces retries a failed capture lookup twice before showing a recoverable error. Wake recovery waits up to five seconds for the sensor, and duplicate wake notifications do not interrupt an active session. Turning Hinge off cancels pending recovery.
+Sensor loss cancels both startup and active capture. Switching Spaces uses the full display frame directly, without enumerating shareable content. Capture restarts only when the display area changes. Wake recovery waits up to five seconds for the sensor, and duplicate wake notifications do not interrupt an active session. Turning Hinge off cancels pending recovery.

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -159,7 +159,7 @@ final class LiveDesktop: NSObject, ObservableObject {
         display: display, excludingApplications: ownApplications, exceptingWindows: ownWindows)
       capturedDisplayID = display.displayID
       includedWindowIDs = Set(ownWindows.map(\.windowID))
-      let area = captureArea(screen: screen, displayID: display.displayID, windows: content.windows)
+      let area = screen.frame
       let configuration = SCStreamConfiguration()
       configuration.sourceRect = CGRect(
         x: area.minX - screen.frame.minX, y: screen.frame.maxY - area.maxY, width: area.width,
@@ -265,49 +265,27 @@ final class LiveDesktop: NSObject, ObservableObject {
     }
   }
 
-  private func captureArea(screen: NSScreen, displayID _: CGDirectDisplayID, windows _: [SCWindow])
-    -> CGRect
-  {
-    screen.frame
-  }
-
-  private func refreshSpace(attempt: Int = 0) {
+  private func refreshSpace() {
     guard isActive, !resumeAfterWake else { return }
     displayTask?.cancel()
     let refreshSession = session
     displayTask = Task { [weak self] in
-      do {
-        try await Task.sleep(for: .milliseconds(400))
-        guard let self, self.isActive, let displayID = self.capturedDisplayID,
-          let screen = NSScreen.screens.first(where: {
-            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
-              .uint32Value == displayID
-          })
-        else { return }
-        let currentSession = self.session
-        let content = try await SCShareableContent.excludingDesktopWindows(
-          false, onScreenWindowsOnly: true)
-        guard !Task.isCancelled, self.session == currentSession else { return }
-        self.displayTask = nil
-        let area = self.captureArea(screen: screen, displayID: displayID, windows: content.windows)
-        if self.overlay?.frame != area {
-          self.stop()
-          await self.start()
-        } else {
-          self.overlay?.orderFrontRegardless()
-        }
-      } catch {
-        guard let self, !Task.isCancelled, self.session == refreshSession, self.isActive else {
-          return
-        }
-        self.displayTask = nil
-        if attempt < 2 {
-          self.refreshSpace(attempt: attempt + 1)
-        } else {
-          self.stop()
-          self.error =
-            "Could not update the desktop after switching Spaces. Turn Hinge on to retry."
-        }
+      do { try await Task.sleep(for: .milliseconds(400)) } catch { return }
+      guard let self, !Task.isCancelled, self.session == refreshSession,
+        self.isActive, !self.resumeAfterWake
+      else { return }
+      self.displayTask = nil
+      guard let displayID = self.capturedDisplayID,
+        let screen = NSScreen.screens.first(where: {
+          ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+            .uint32Value == displayID
+        })
+      else { return }
+      if self.overlay?.frame != screen.frame {
+        self.stop()
+        await self.start()
+      } else {
+        self.overlay?.orderFrontRegardless()
       }
     }
   }

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -265,19 +265,10 @@ final class LiveDesktop: NSObject, ObservableObject {
     }
   }
 
-  private func captureArea(screen: NSScreen, displayID: CGDirectDisplayID, windows: [SCWindow])
+  private func captureArea(screen: NSScreen, displayID _: CGDirectDisplayID, windows _: [SCWindow])
     -> CGRect
   {
-    let bounds = CGDisplayBounds(displayID)
-    let minimumHeight = bounds.height - screen.safeAreaInsets.top - 2
-    let fullscreen = windows.contains {
-      $0.isOnScreen && $0.windowLayer == 0
-        && $0.owningApplication?.processID != ProcessInfo.processInfo.processIdentifier
-        && $0.frame.height >= minimumHeight
-        && $0.frame.intersection(bounds).width > bounds.width * 0.2
-        && abs($0.frame.maxY - bounds.maxY) <= 2
-    }
-    return fullscreen ? screen.frame : screen.visibleFrame
+    screen.frame
   }
 
   private func refreshSpace(attempt: Int = 0) {


### PR DESCRIPTION
Cover the entire display and refresh Spaces without redundant window enumeration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen captures now consistently include the full screen area, including regions previously excluded by fullscreen-window detection or visible-frame boundaries.
  * Switching between Spaces now uses the complete display frame, and capture restarts only when the display area changes.
  * Failed capture lookups no longer retry or display a recoverable error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->