### PR TITLE
Support checks before Python 3.11

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -3,7 +3,6 @@ import re
 import shutil
 import subprocess
 import sys
-import tomllib
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -12,6 +11,11 @@ from pygments import lex
 from pygments.lexers import get_lexer_by_name, get_lexer_for_filename
 from pygments.token import Comment, String
 from pygments.util import ClassNotFound
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parent.parent
 BIOME = {".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc", ".css", ".html"}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 Pygments==2.21.0
 PyYAML==6.0.3
 ruff==0.16.6
+tomli==2.2.1; python_version < "3.11"


### PR DESCRIPTION
Use the tomli backport on Python versions before 3.11 so local repository checks can parse TOML configuration. Closes #5.