### PR TITLE
Add Launch at Login setting

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1,7 +1,10 @@
+import ServiceManagement
 import SwiftUI
 
 struct SettingsView: View {
   @ObservedObject var desktop: LiveDesktop
+  @State private var loginItemStatus = SMAppService.mainApp.status
+  @State private var loginItemError: String?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 24) {
@@ -47,8 +50,23 @@ struct SettingsView: View {
           Button("Set open position") { desktop.setOpenPosition() }
             .disabled(!desktop.sensorAvailable || desktop.isStarting)
         }
+        Divider()
+        Toggle("Launch at login", isOn: launchAtLogin)
+          .toggleStyle(.switch)
+        if loginItemStatus == .requiresApproval {
+          Button("Approval required in Login Items") {
+            SMAppService.openSystemSettingsLoginItems()
+          }
+          .buttonStyle(.link)
+        }
       }
       .font(.system(size: 12))
+      if let loginItemError {
+        Text(loginItemError)
+          .font(.system(size: 12))
+          .foregroundStyle(.orange)
+          .fixedSize(horizontal: false, vertical: true)
+      }
       if let error = desktop.error {
         VStack(alignment: .leading, spacing: 8) {
           Text(error).foregroundStyle(.orange)
@@ -75,5 +93,32 @@ struct SettingsView: View {
     .padding(28)
     .padding(.top, 12)
     .frame(width: 376)
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
+    {
+      _ in
+      loginItemStatus = SMAppService.mainApp.status
+    }
+  }
+
+  private var launchAtLogin: Binding<Bool> {
+    Binding(
+      get: {
+        loginItemStatus == .enabled || loginItemStatus == .requiresApproval
+      },
+      set: setLaunchAtLogin)
+  }
+
+  private func setLaunchAtLogin(_ enabled: Bool) {
+    do {
+      if enabled {
+        try SMAppService.mainApp.register()
+      } else {
+        try SMAppService.mainApp.unregister()
+      }
+      loginItemError = nil
+    } catch {
+      loginItemError = "Could not update Launch at Login: \(error.localizedDescription)"
+    }
+    loginItemStatus = SMAppService.mainApp.status
   }
 }


### PR DESCRIPTION
Add a Launch at login setting using native macOS registration, with approval status and error handling. Closes #7.