### PR TITLE
Add adjustable effect strength

### DIFF
--- a/Sources/DesktopRenderer.swift
+++ b/Sources/DesktopRenderer.swift
@@ -23,6 +23,7 @@ final class DesktopRenderer: NSObject, MTKViewDelegate {
   private var blurredGeneration: UInt64?
   private let motion: LidMotion
   private var wasPresented = false
+  var effectStrength: Float = 1
   var presentationTime: CFTimeInterval?
   var onPresentation: ((Error?) -> Void)?
   var onRest: (() -> Void)?
@@ -149,7 +150,7 @@ final class DesktopRenderer: NSObject, MTKViewDelegate {
   func draw(in view: MTKView) {
     let time = presentationTime ?? CACurrentMediaTime()
     presentationTime = nil
-    let progress = motion.sample(at: time)
+    let progress = motion.sample(at: time) * effectStrength
     guard progress > 0 else {
       clear(view)
       return

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -127,9 +127,11 @@ final class LiveDesktop: NSObject, ObservableObject {
 
   func setEffectStrength(_ value: Double) {
     let strength = value.isFinite ? min(max(value, 0.25), 1) : 1
+    guard strength != effectStrength else { return }
     effectStrength = strength
     UserDefaults.standard.set(strength, forKey: "effectStrength")
     renderer?.effectStrength = Float(strength)
+    NSHapticFeedbackManager.defaultPerformer.perform(.levelChange, performanceTime: .now)
   }
 
   func start() async {

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -34,6 +34,7 @@ final class LiveDesktop: NSObject, ObservableObject {
   @Published private(set) var isStarting = false
   @Published private(set) var sensorAvailable = false
   @Published private(set) var openAngle: Double
+  @Published private(set) var effectStrength: Double
   @Published private(set) var error: String?
   @Published private(set) var needsPermission = false
   private let sensor = LidSensor()
@@ -55,7 +56,11 @@ final class LiveDesktop: NSObject, ObservableObject {
   override init() {
     let savedAngle = UserDefaults.standard.object(forKey: "openAngle") as? Double ?? 100
     let openAngle = savedAngle.isFinite && (25...180).contains(savedAngle) ? savedAngle : 100
+    let savedStrength = UserDefaults.standard.object(forKey: "effectStrength") as? Double ?? 1
+    let effectStrength =
+      savedStrength.isFinite && (0.25...1).contains(savedStrength) ? savedStrength : 1
     self.openAngle = openAngle
+    self.effectStrength = effectStrength
     motion = LidMotion(openAngle: openAngle)
     super.init()
     let motion = motion
@@ -120,6 +125,13 @@ final class LiveDesktop: NSObject, ObservableObject {
     metalView?.draw()
   }
 
+  func setEffectStrength(_ value: Double) {
+    let strength = value.isFinite ? min(max(value, 0.25), 1) : 1
+    effectStrength = strength
+    UserDefaults.standard.set(strength, forKey: "effectStrength")
+    renderer?.effectStrength = Float(strength)
+  }
+
   func start() async {
     guard !isStarting, !isActive else { return }
     error = nil
@@ -140,6 +152,7 @@ final class LiveDesktop: NSObject, ObservableObject {
     self.session = session
     do {
       let renderer = try DesktopRenderer(resources: .main, motion: motion)
+      renderer.effectStrength = Float(effectStrength)
       let content = try await SCShareableContent.excludingDesktopWindows(
         false, onScreenWindowsOnly: true)
       guard self.session == session else { return }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -38,6 +38,25 @@ struct SettingsView: View {
         Divider()
         HStack {
           VStack(alignment: .leading, spacing: 4) {
+            Text("Effect strength").fontWeight(.medium)
+            Text("\(Int(desktop.effectStrength * 100))%")
+              .foregroundStyle(.secondary)
+              .monospacedDigit()
+          }
+          Spacer()
+          Slider(
+            value: Binding(
+              get: { desktop.effectStrength },
+              set: { desktop.setEffectStrength($0) }),
+            in: 0.25...1, step: 0.05
+          )
+          .frame(width: 140)
+          .accessibilityLabel("Effect strength")
+          .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
+        }
+        Divider()
+        HStack {
+          VStack(alignment: .leading, spacing: 4) {
             Text("Open position").fontWeight(.medium)
             Text("\(Int(desktop.openAngle))°")
               .foregroundStyle(.secondary)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -50,9 +50,13 @@ struct SettingsView: View {
               set: { desktop.setEffectStrength($0) }),
             in: 0.25...1, step: 0.05
           )
-          .frame(width: 140)
+          .frame(width: 100)
           .accessibilityLabel("Effect strength")
           .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
+          Button("Default") { desktop.setEffectStrength(1) }
+            .disabled(desktop.effectStrength == 1)
+            .help("Reset effect strength to 100%")
+            .accessibilityLabel("Reset effect strength to default")
         }
         Divider()
         HStack {


### PR DESCRIPTION
Add persisted effect strength from 25% to 100%, with haptic feedback and a Default reset button. Closes #9.