### PR TITLE
Bring the capture area and download notes up to date

### DIFF
--- a/MOTION.md
+++ b/MOTION.md
@@ -27,7 +27,7 @@ The new projection keeps the top and bottom edges at their original height. Its 
 
 Three cached Gaussian blur levels at nominal widths of 6, 16, and 36 pixels per 786-pixel reference width provide continuous progressive blur. Blur strength varies with closure and fades toward the lower tenth of the desktop. Subtle top-corner shading and side feathering complete the single effect. The side gaps extend the nearest desktop edge using the cached broad blur texture, with a soft blend into the folded image. An inverse projection in the fragment shader preserves the fold geometry while covering the full overlay. This adds no capture, blur pass, or intermediate texture.
 
-The effect covers the built-in screen's usable desktop area, excluding the normal menu bar and Dock. A non-activating panel joins fullscreen Spaces without taking keyboard focus. Space changes refresh the capture area: fullscreen content uses the whole display, while the regular desktop keeps the menu bar and Dock stationary.
+The effect covers the built-in screen's full display frame, including the menu bar and Dock. A non-activating panel joins fullscreen Spaces without taking keyboard focus. Space changes keep the same capture area and bring the panel back to the front.
 
 ## Motion timing
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,6 @@ The website's `/download` endpoint serves the current release's `Hinge.dmg`. It 
 
 Import the repository into Vercel with `web` as its root directory and `main` as its production branch. No build or install command is needed. Once connected, Vercel deploys future pushes automatically.
 
-The landing page lives in `web/index.html`, with styles and the original demo recording in `web/assets/`. Its download button uses `/download` to serve the latest release. For this private repository, configure a server-only `GITHUB_TOKEN` in Vercel with read-only Contents access to `Noveum/hinge`.
+The landing page lives in `web/index.html`, with styles and the original demo recording in `web/assets/`. Its download button uses `/download` to serve the latest release. The repository is public, so the endpoint works without credentials. An optional server-only `GITHUB_TOKEN` in Vercel with read-only Contents access to `Noveum/hinge` raises the GitHub API limit from 60 to 5,000 requests per hour.
 
 CI finishes by checking the deployed website assets, video seeking, and the public installer checksum against the new release. Deployment failures leave a failed workflow instead of a false success.

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,7 @@ Live at [hinge.noveum.ai](https://hinge.noveum.ai/). The download button uses [h
 
 Vercel uses `web` as the root directory and `main` as the production branch. Push to `main` to deploy. Branches get preview deployments.
 
-Downloads from the private repository need a server-only `GITHUB_TOKEN` environment variable in Vercel with read-only Contents access to `Noveum/hinge`. The endpoint redirects to the latest release's `Hinge.dmg` without exposing the token.
+The repository is public, so downloads work without credentials. An optional server-only `GITHUB_TOKEN` environment variable in Vercel, with read-only Contents access to `Noveum/hinge`, raises the GitHub API limit from 60 to 5,000 requests per hour. The endpoint redirects to the latest release's `Hinge.dmg` without exposing the token.
 
 ## Preview
 


### PR DESCRIPTION
Since #1 switched the overlay to the full display frame, MOTION.md still described a capture area that excluded the menu bar and Dock, plus a Space refresh that no longer happens. RELEASE.md and web/README.md still called the repository private and the download token required. The repository is public, so the token is optional and only raises the GitHub API limit from 60 to 5,000 requests per hour.

Docs only. Validated with `python3 scripts/check.py policy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Motion effects now cover the built-in display’s full frame, including the menu bar and Dock.
  - Space changes preserve the capture area and restore the fullscreen panel without refreshing or repositioning desktop elements.

- **Documentation**
  - Updated release and deployment guidance to reflect the public repository.
  - Clarified that downloads work without credentials; an optional token increases the GitHub API rate limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->