### PR TITLE
Explain when a Mac has no lid angle sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ScreenCaptureKit supplies your live desktop, and Metal adds perspective and prog
 
 ## Install
 
-Requires an Apple silicon MacBook with a supported lid sensor and macOS 14 or later.
+Requires an Apple silicon MacBook with a supported lid sensor and macOS 14 or later. Not every MacBook has one; Hinge tells you if yours doesn't.
 
 [Download Hinge](https://hinge.noveum.ai/download), open the DMG, and drag Hinge into Applications. This prototype is not notarized; macOS may ask you to approve it under Privacy & Security.
 

--- a/Sources/LidSensor.swift
+++ b/Sources/LidSensor.swift
@@ -5,7 +5,9 @@ final class LidSensor {
   private let queue = DispatchQueue(label: "hinge.sensor", qos: .userInteractive)
   private var connection: LidConnection?
   private var tracking = false
+  private var hasConnected = false
   var onAngle: ((Double?) -> Void)?
+  var onMissing: (() -> Void)?
 
   func start() {
     queue.async { [weak self] in self?.connect() }
@@ -35,10 +37,15 @@ final class LidSensor {
       kIOHIDDeviceUsageKey: 0x008A,
     ]
     IOHIDManagerSetDeviceMatching(manager, matching as CFDictionary)
-    guard IOHIDManagerOpen(manager, 0) == kIOReturnSuccess,
-      let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice>
+    guard IOHIDManagerOpen(manager, 0) == kIOReturnSuccess else {
+      IOHIDManagerClose(manager, 0)
+      onAngle?(nil)
+      return
+    }
+    guard let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice>, !devices.isEmpty
     else {
       IOHIDManagerClose(manager, 0)
+      if !hasConnected { onMissing?() }
       onAngle?(nil)
       return
     }
@@ -53,6 +60,7 @@ final class LidSensor {
         self?.onAngle?(value)
       }
       self.connection = connection
+      hasConnected = true
       onAngle?(angle)
       connection.setTracking(tracking)
       return

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -37,7 +37,10 @@ final class LiveDesktop: NSObject, ObservableObject {
   @Published private(set) var effectStrength: Double
   @Published private(set) var error: String?
   @Published private(set) var needsPermission = false
+  private static let missingSensorMessage =
+    "This Mac doesn't appear to have a lid angle sensor, so Hinge can't follow the lid."
   private let sensor = LidSensor()
+  private var sensorMissing = false
   private let motion: LidMotion
   private var stream: SCStream?
   private var frames: ScreenFrames?
@@ -71,12 +74,23 @@ final class LiveDesktop: NSObject, ObservableObject {
         guard let self else { return }
         if update.availabilityChanged {
           self.sensorAvailable = update.available
+          if update.available, self.sensorMissing {
+            self.sensorMissing = false
+            if self.error == Self.missingSensorMessage { self.error = nil }
+          }
           if !update.available, self.isActive || self.isStarting {
             self.stop()
             self.error = "The lid sensor stopped responding. Turn Hinge on again to reconnect."
           }
         }
         if update.beganClosing { self.beginRendering() }
+      }
+    }
+    sensor.onMissing = { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self, !self.sensorAvailable else { return }
+        self.sensorMissing = true
+        if self.error == nil { self.error = Self.missingSensorMessage }
       }
     }
     sensor.start()
@@ -140,7 +154,10 @@ final class LiveDesktop: NSObject, ObservableObject {
     needsPermission = false
     guard sensorAvailable else {
       sensor.reconnect()
-      error = "The lid sensor is unavailable. Reconnecting, try turning Hinge on again in a moment."
+      error =
+        sensorMissing
+        ? Self.missingSensorMessage
+        : "The lid sensor is unavailable. Reconnecting, try turning Hinge on again in a moment."
       return
     }
     guard CGPreflightScreenCaptureAccess() || CGRequestScreenCaptureAccess() else {


### PR DESCRIPTION
Relates to #2.

On MacBooks without the sensor, Hinge said it was reconnecting and asked the user to try again, which could never succeed. When the HID manager opens but finds no matching device, and no device was ever connected in this session, Settings now says right away that this Mac doesn't appear to have a lid angle sensor. Turning Hinge on repeats that message instead of the retry hint. A device that appears later clears it, and a device that was seen before is still treated as temporarily unavailable, so wake and reconnect behave as before.

Validated with `swift-format lint --strict Sources/*.swift`, `python3 scripts/check.py policy`, and `make build`. Both paths were checked against IOKit: the real matching dictionary never reports a missing sensor, and a matching dictionary with no devices reports it on start and on reconnect.
