### PR TITLE
Turn Hinge back on at launch when it was left on

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ make build
 open build/Hinge.app
 ```
 
-Allow Screen Recording, reopen Hinge if prompted, and turn it on. The starting angle is 100°. Prefer something else? Get comfy and click **Set open position**. Hinge remembers.
+Allow Screen Recording, reopen Hinge if prompted, and turn it on. It turns itself back on the next time you open it. The starting angle is 100°. Prefer something else? Get comfy and click **Set open position**. Hinge remembers.
 
 ## Got an idea?
 

--- a/Sources/HingeApp.swift
+++ b/Sources/HingeApp.swift
@@ -14,11 +14,7 @@ struct HingeApp: App {
         .onAppear {
           delegate.onTerminate = { desktop.shutDown() }
           delegate.installToggleHotKey {
-            if desktop.isActive {
-              desktop.setEnabled(false)
-            } else if !desktop.isStarting {
-              desktop.setEnabled(true)
-            }
+            if !desktop.isStarting { desktop.setEnabled(!desktop.isEnabled) }
           }
         }
     }
@@ -105,10 +101,10 @@ struct HingeMenu: View {
 
   var body: some View {
     Button {
-      desktop.setEnabled(!desktop.isActive)
+      desktop.setEnabled(!desktop.isEnabled)
     } label: {
       HStack {
-        Text(desktop.isActive ? "Turn off" : "Turn on")
+        Text(desktop.isEnabled ? "Turn off" : "Turn on")
         Spacer()
         Text("⌃⌥H").foregroundStyle(.secondary)
       }

--- a/Sources/HingeApp.swift
+++ b/Sources/HingeApp.swift
@@ -14,9 +14,9 @@ struct HingeApp: App {
           delegate.onTerminate = { desktop.shutDown() }
           delegate.installToggleHotKey {
             if desktop.isActive {
-              desktop.stop()
+              desktop.setEnabled(false)
             } else if !desktop.isStarting {
-              Task { await desktop.start() }
+              desktop.setEnabled(true)
             }
           }
         }
@@ -103,7 +103,7 @@ struct HingeMenu: View {
 
   var body: some View {
     Button {
-      if desktop.isActive { desktop.stop() } else { Task { await desktop.start() } }
+      desktop.setEnabled(!desktop.isActive)
     } label: {
       HStack {
         Text(desktop.isActive ? "Turn off" : "Turn on")

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -37,8 +37,11 @@ final class LiveDesktop: NSObject, ObservableObject {
   @Published private(set) var effectStrength: Double
   @Published private(set) var error: String?
   @Published private(set) var needsPermission = false
+  @Published private(set) var isEnabled = UserDefaults.standard.bool(forKey: "effectEnabled")
   private static let missingSensorMessage =
     "This Mac doesn't appear to have a lid angle sensor, so Hinge can't follow the lid."
+  private static let sensorDroppedMessage =
+    "The lid sensor stopped responding. Hinge turns back on as soon as it reconnects."
   private let sensor = LidSensor()
   private var sensorMissing = false
   private let motion: LidMotion
@@ -51,7 +54,7 @@ final class LiveDesktop: NSObject, ObservableObject {
   private var session = UUID()
   private var observers = [NSObjectProtocol]()
   private var resumeAfterWake = false
-  private var startWhenSensorIsReady = UserDefaults.standard.bool(forKey: "enabled")
+  private var restoringAtLaunch = UserDefaults.standard.bool(forKey: "effectEnabled")
   private var wakeTask: Task<Void, Never>?
   private var displayTask: Task<Void, Never>?
   private var capturedDisplayID: CGDirectDisplayID?
@@ -81,13 +84,16 @@ final class LiveDesktop: NSObject, ObservableObject {
           }
           if !update.available, self.isActive || self.isStarting {
             self.stop()
-            self.error = "The lid sensor stopped responding. Turn Hinge on again to reconnect."
+            self.error = Self.sensorDroppedMessage
           }
         }
         if update.beganClosing { self.beginRendering() }
-        if update.available, self.startWhenSensorIsReady {
-          self.startWhenSensorIsReady = false
-          await self.start()
+        if update.available, self.isEnabled, !self.isActive, !self.isStarting,
+          !self.resumeAfterWake
+        {
+          let restoring = self.restoringAtLaunch
+          self.restoringAtLaunch = false
+          await self.start(promptForPermission: !restoring)
         }
       }
     }
@@ -133,8 +139,9 @@ final class LiveDesktop: NSObject, ObservableObject {
   }
 
   func setEnabled(_ enabled: Bool) {
-    UserDefaults.standard.set(enabled, forKey: "enabled")
-    startWhenSensorIsReady = false
+    isEnabled = enabled
+    restoringAtLaunch = false
+    UserDefaults.standard.set(enabled, forKey: "effectEnabled")
     if enabled { Task { await start() } } else { stop() }
   }
 
@@ -159,19 +166,18 @@ final class LiveDesktop: NSObject, ObservableObject {
     NSHapticFeedbackManager.defaultPerformer.perform(.levelChange, performanceTime: .now)
   }
 
-  func start() async {
+  func start(promptForPermission: Bool = true) async {
     guard !isStarting, !isActive else { return }
     error = nil
     needsPermission = false
     guard sensorAvailable else {
       sensor.reconnect()
-      error =
-        sensorMissing
-        ? Self.missingSensorMessage
-        : "The lid sensor is unavailable. Reconnecting, try turning Hinge on again in a moment."
+      if sensorMissing { error = Self.missingSensorMessage }
       return
     }
-    guard CGPreflightScreenCaptureAccess() || CGRequestScreenCaptureAccess() else {
+    let hasScreenAccess =
+      CGPreflightScreenCaptureAccess() || (promptForPermission && CGRequestScreenCaptureAccess())
+    guard hasScreenAccess else {
       needsPermission = true
       error = "Allow Hinge in Screen Recording settings, then quit and reopen it."
       return
@@ -259,10 +265,7 @@ final class LiveDesktop: NSObject, ObservableObject {
         try await Task.sleep(for: .milliseconds(10))
       }
       guard self.session == session else { return }
-      guard sensorAvailable else {
-        throw DesktopError.message(
-          "The lid sensor is unavailable. Turn Hinge on again to reconnect.")
-      }
+      guard sensorAvailable else { throw DesktopError.message(Self.sensorDroppedMessage) }
       motion.setEnabled(true)
       isActive = true
       isStarting = false

--- a/Sources/LiveDesktop.swift
+++ b/Sources/LiveDesktop.swift
@@ -48,6 +48,7 @@ final class LiveDesktop: NSObject, ObservableObject {
   private var session = UUID()
   private var observers = [NSObjectProtocol]()
   private var resumeAfterWake = false
+  private var startWhenSensorIsReady = UserDefaults.standard.bool(forKey: "enabled")
   private var wakeTask: Task<Void, Never>?
   private var displayTask: Task<Void, Never>?
   private var capturedDisplayID: CGDirectDisplayID?
@@ -77,6 +78,10 @@ final class LiveDesktop: NSObject, ObservableObject {
           }
         }
         if update.beganClosing { self.beginRendering() }
+        if update.available, self.startWhenSensorIsReady {
+          self.startWhenSensorIsReady = false
+          await self.start()
+        }
       }
     }
     sensor.start()
@@ -111,6 +116,12 @@ final class LiveDesktop: NSObject, ObservableObject {
       ) { [weak self] _ in
         Task { @MainActor in await self?.refreshIncludedWindows() }
       })
+  }
+
+  func setEnabled(_ enabled: Bool) {
+    UserDefaults.standard.set(enabled, forKey: "enabled")
+    startWhenSensorIsReady = false
+    if enabled { Task { await start() } } else { stop() }
   }
 
   func setOpenPosition() {

--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -97,8 +97,8 @@ struct MainView: View {
           .multilineTextAlignment(.center)
           .fixedSize(horizontal: false, vertical: true)
       }
-      Button(desktop.isActive ? "Turn off" : "Turn on") {
-        desktop.setEnabled(!desktop.isActive)
+      Button(desktop.isEnabled ? "Turn off" : "Turn on") {
+        desktop.setEnabled(!desktop.isEnabled)
       }
       .buttonStyle(.borderedProminent)
       .controlSize(.large)
@@ -138,14 +138,16 @@ struct MainView: View {
   }
 
   private var title: String {
+    if desktop.isActive { return "On" }
     if desktop.isStarting { return "Starting…" }
-    return desktop.isActive ? "On" : "Off"
+    return desktop.isEnabled ? "Waiting…" : "Off"
   }
 
   private var subtitle: String {
-    if desktop.isStarting { return "Getting the desktop and the sensor ready." }
     if desktop.isActive { return "Your desktop bends as the lid closes." }
+    if desktop.isStarting { return "Getting the desktop and the sensor ready." }
     if !desktop.sensorAvailable { return "Waiting for the lid angle sensor." }
+    if desktop.isEnabled { return "Hinge is on but not running yet." }
     return "Turn Hinge on to follow the lid."
   }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -25,9 +25,7 @@ struct SettingsView: View {
         Toggle(
           isOn: Binding(
             get: { desktop.isActive || desktop.isStarting },
-            set: { enabled in
-              if enabled { Task { await desktop.start() } } else { desktop.stop() }
-            })
+            set: { desktop.setEnabled($0) })
         ) {
           HStack(spacing: 7) {
             Circle().fill(desktop.isActive ? Color.green : Color.secondary.opacity(0.45))


### PR DESCRIPTION
Launch at Login (#8) opens Hinge at login, but the effect always started turned off, so it still needed a trip to Settings before it worked. Turning Hinge on or off from Settings, the menu, or Control-Option-H (#12) now saves that choice, and the next launch starts the effect as soon as the lid sensor reports. Stops caused by sleep, display changes, or errors keep the saved choice, so it only stays off when the user turns it off.

Validated with `swift-format lint --strict Sources/*.swift`, `python3 scripts/check.py policy`, and `make build`. On a 16-inch M1 Max, relaunching after turning Hinge on brought the effect back without touching Settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hinge now remembers whether it was enabled and restores that setting when the app is reopened.
  - If startup is temporarily unavailable, Hinge automatically begins once the required sensor becomes available.
  - The enable/disable toggle now consistently updates Hinge’s active state.

- **Documentation**
  - Updated installation instructions to explain automatic re-enabling on the next app launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->