### PR TITLE
Rebuild Settings as a sidebar with grouped cards

### DIFF
--- a/Hinge.xcodeproj/project.pbxproj
+++ b/Hinge.xcodeproj/project.pbxproj
@@ -118,6 +118,24 @@
 			<key>fileRef</key>
 			<string>5A1C0E7B9D2F4A6E8B3C1D07</string>
 		</dict>
+		<key>2B7D4E1A6C3F5089AD41E2C3</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>MainView.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9C0F3A5B7D1E2648BF05A731</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>fileRef</key>
+			<string>2B7D4E1A6C3F5089AD41E2C3</string>
+		</dict>
 		<key>EEDE96C56CBAC202420A47BC</key>
 		<dict>
 			<key>isa</key>
@@ -184,6 +202,7 @@
 				<string>75017C803F3BD9BCA2AD760F</string>
 				<string>4A57EFA62E37A174C03C000F</string>
 				<string>5A1C0E7B9D2F4A6E8B3C1D07</string>
+				<string>2B7D4E1A6C3F5089AD41E2C3</string>
 				<string>EEDE96C56CBAC202420A47BC</string>
 			</array>
 			<key>path</key>
@@ -270,6 +289,7 @@
 				<string>4F87324F1438ABED37B95379</string>
 				<string>DAEA9D08F6B5E79A226FC00D</string>
 				<string>7E2B4C6D8F0A1B3C5D7E9F11</string>
+				<string>9C0F3A5B7D1E2648BF05A731</string>
 				<string>289C8D3C22097DA2A314830F</string>
 			</array>
 			<key>runOnlyForDeploymentPostprocessing</key>

--- a/Hinge.xcodeproj/project.pbxproj
+++ b/Hinge.xcodeproj/project.pbxproj
@@ -100,6 +100,24 @@
 			<key>fileRef</key>
 			<string>4A57EFA62E37A174C03C000F</string>
 		</dict>
+		<key>5A1C0E7B9D2F4A6E8B3C1D07</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>SettingsChrome.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7E2B4C6D8F0A1B3C5D7E9F11</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>fileRef</key>
+			<string>5A1C0E7B9D2F4A6E8B3C1D07</string>
+		</dict>
 		<key>EEDE96C56CBAC202420A47BC</key>
 		<dict>
 			<key>isa</key>
@@ -165,6 +183,7 @@
 				<string>97A67C54A25B904AD25CBA32</string>
 				<string>75017C803F3BD9BCA2AD760F</string>
 				<string>4A57EFA62E37A174C03C000F</string>
+				<string>5A1C0E7B9D2F4A6E8B3C1D07</string>
 				<string>EEDE96C56CBAC202420A47BC</string>
 			</array>
 			<key>path</key>
@@ -250,6 +269,7 @@
 				<string>1A5512770BFACF9F16B16FF9</string>
 				<string>4F87324F1438ABED37B95379</string>
 				<string>DAEA9D08F6B5E79A226FC00D</string>
+				<string>7E2B4C6D8F0A1B3C5D7E9F11</string>
 				<string>289C8D3C22097DA2A314830F</string>
 			</array>
 			<key>runOnlyForDeploymentPostprocessing</key>

--- a/Sources/HingeApp.swift
+++ b/Sources/HingeApp.swift
@@ -8,8 +8,8 @@ struct HingeApp: App {
   @StateObject private var desktop = LiveDesktop()
 
   var body: some Scene {
-    Window("Hinge", id: "settings") {
-      SettingsView(desktop: desktop)
+    Window("Hinge", id: "main") {
+      MainView(desktop: desktop)
         .onAppear {
           delegate.onTerminate = { desktop.shutDown() }
           delegate.installToggleHotKey {
@@ -31,6 +31,12 @@ struct HingeApp: App {
         )
       }
     }
+    Window("Settings", id: "settings") {
+      SettingsView(desktop: desktop)
+    }
+    .windowStyle(.hiddenTitleBar)
+    .windowResizability(.contentSize)
+    .defaultPosition(.center)
     MenuBarExtra(
       "Hinge", systemImage: desktop.isActive ? "laptopcomputer.and.arrow.down" : "laptopcomputer"
     ) {
@@ -115,6 +121,10 @@ struct HingeMenu: View {
     Button("Set open position") { desktop.setOpenPosition() }
       .disabled(!desktop.sensorAvailable || desktop.isStarting)
     Divider()
+    Button("Open Hinge") {
+      openWindow(id: "main")
+      NSApp.activate(ignoringOtherApps: true)
+    }
     Button("Settings…") {
       openWindow(id: "settings")
       NSApp.activate(ignoringOtherApps: true)

--- a/Sources/HingeApp.swift
+++ b/Sources/HingeApp.swift
@@ -6,10 +6,11 @@ import SwiftUI
 struct HingeApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
   @StateObject private var desktop = LiveDesktop()
+  @StateObject private var navigator = Navigator()
 
   var body: some Scene {
     Window("Hinge", id: "main") {
-      MainView(desktop: desktop)
+      MainView(desktop: desktop, navigator: navigator)
         .onAppear {
           delegate.onTerminate = { desktop.shutDown() }
           delegate.installToggleHotKey {
@@ -31,21 +32,11 @@ struct HingeApp: App {
         )
       }
     }
-    settingsWindow
     MenuBarExtra(
       "Hinge", systemImage: desktop.isActive ? "laptopcomputer.and.arrow.down" : "laptopcomputer"
     ) {
-      HingeMenu(desktop: desktop)
+      HingeMenu(desktop: desktop, navigator: navigator)
     }
-  }
-
-  private var settingsWindow: some Scene {
-    Window("Settings", id: "settings") {
-      SettingsView(desktop: desktop)
-    }
-    .windowStyle(.hiddenTitleBar)
-    .windowResizability(.contentSize)
-    .defaultPosition(.center)
   }
 }
 
@@ -109,6 +100,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 struct HingeMenu: View {
   @ObservedObject var desktop: LiveDesktop
+  @ObservedObject var navigator: Navigator
   @Environment(\.openWindow) private var openWindow
 
   var body: some View {
@@ -126,11 +118,13 @@ struct HingeMenu: View {
       .disabled(!desktop.sensorAvailable || desktop.isStarting)
     Divider()
     Button("Open Hinge") {
+      navigator.screen = .main
       openWindow(id: "main")
       NSApp.activate(ignoringOtherApps: true)
     }
     Button("Settings…") {
-      openWindow(id: "settings")
+      navigator.screen = .settings
+      openWindow(id: "main")
       NSApp.activate(ignoringOtherApps: true)
     }.keyboardShortcut(",")
     Button("Quit Hinge") { NSApp.terminate(nil) }.keyboardShortcut("q")

--- a/Sources/HingeApp.swift
+++ b/Sources/HingeApp.swift
@@ -31,17 +31,21 @@ struct HingeApp: App {
         )
       }
     }
+    settingsWindow
+    MenuBarExtra(
+      "Hinge", systemImage: desktop.isActive ? "laptopcomputer.and.arrow.down" : "laptopcomputer"
+    ) {
+      HingeMenu(desktop: desktop)
+    }
+  }
+
+  private var settingsWindow: some Scene {
     Window("Settings", id: "settings") {
       SettingsView(desktop: desktop)
     }
     .windowStyle(.hiddenTitleBar)
     .windowResizability(.contentSize)
     .defaultPosition(.center)
-    MenuBarExtra(
-      "Hinge", systemImage: desktop.isActive ? "laptopcomputer.and.arrow.down" : "laptopcomputer"
-    ) {
-      HingeMenu(desktop: desktop)
-    }
   }
 }
 

--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -1,0 +1,155 @@
+import AppKit
+import SwiftUI
+
+struct MainView: View {
+  @ObservedObject var desktop: LiveDesktop
+  @Environment(\.openWindow) private var openWindow
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Divider().opacity(0.6)
+      ScrollView {
+        VStack(spacing: 20) {
+          hero
+          if let error = desktop.error { errorCard(error) }
+          positionCard
+        }
+        .padding(EdgeInsets(top: 22, leading: 20, bottom: 22, trailing: 20))
+      }
+      .background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea())
+    }
+    .frame(width: 420, height: 470)
+  }
+
+  private var header: some View {
+    ZStack {
+      Text("Hinge")
+        .font(.system(size: 13, weight: .semibold))
+      HStack(spacing: 0) {
+        Spacer(minLength: 0)
+        HeaderButton(symbol: "gearshape.fill", help: "Settings") {
+          openWindow(id: "settings")
+          NSApp.activate(ignoringOtherApps: true)
+        }
+        .keyboardShortcut(",", modifiers: .command)
+      }
+      .padding(.trailing, 12)
+    }
+    .frame(height: 40)
+    .background(HeaderMaterial().ignoresSafeArea())
+  }
+
+  private var hero: some View {
+    VStack(spacing: 14) {
+      RoundedRectangle(cornerRadius: 22, style: .continuous)
+        .fill((desktop.isActive ? Color.accentColor : Color.gray).gradient)
+        .frame(width: 84, height: 84)
+        .overlay(
+          Image(
+            systemName: desktop.isActive ? "laptopcomputer.and.arrow.down" : "laptopcomputer"
+          )
+          .font(.system(size: 36, weight: .medium))
+          .foregroundStyle(.white)
+        )
+        .shadow(color: .black.opacity(0.16), radius: 10, y: 4)
+        .animation(.easeOut(duration: 0.2), value: desktop.isActive)
+      VStack(spacing: 4) {
+        Text(title)
+          .font(.system(size: 20, weight: .semibold))
+        Text(subtitle)
+          .font(.system(size: 12))
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Button(desktop.isActive ? "Turn off" : "Turn on") {
+        if desktop.isActive {
+          desktop.stop()
+        } else {
+          Task { await desktop.start() }
+        }
+      }
+      .buttonStyle(.borderedProminent)
+      .controlSize(.large)
+      .disabled(desktop.isStarting)
+      Text("⌃⌥H anywhere")
+        .font(.system(size: 11))
+        .foregroundStyle(.tertiary)
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private var positionCard: some View {
+    SettingsGroup(title: "Open position") {
+      SettingsRow(
+        "angle", tint: .indigo, title: "Open position", subtitle: "\(Int(desktop.openAngle))°"
+      ) {
+        Button("Set") { desktop.setOpenPosition() }
+          .controlSize(.small)
+          .disabled(!desktop.sensorAvailable || desktop.isStarting)
+          .help("Save the lid angle you are viewing at right now")
+      }
+    }
+  }
+
+  private func errorCard(_ message: String) -> some View {
+    SettingsGroup(title: "Attention") {
+      SettingsRow("exclamationmark.triangle.fill", tint: .orange, title: message) {
+        if desktop.needsPermission {
+          Button("Open Settings", action: openScreenRecordingSettings)
+            .controlSize(.small)
+        }
+      }
+    }
+  }
+
+  private var title: String {
+    if desktop.isStarting { return "Starting…" }
+    return desktop.isActive ? "On" : "Off"
+  }
+
+  private var subtitle: String {
+    if desktop.isStarting { return "Getting the desktop and the sensor ready." }
+    if desktop.isActive { return "Your desktop bends as the lid closes." }
+    if !desktop.sensorAvailable { return "Waiting for the lid angle sensor." }
+    return "Turn Hinge on to follow the lid."
+  }
+}
+
+private struct HeaderButton: View {
+  let symbol: String
+  let help: String
+  let action: () -> Void
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: symbol)
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .frame(width: 26, height: 26)
+        .background(
+          RoundedRectangle(cornerRadius: 7, style: .continuous)
+            .fill(Color.primary.opacity(hovering ? 0.09 : 0))
+        )
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .help(help)
+    .accessibilityLabel(help)
+  }
+}
+
+private struct HeaderMaterial: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSVisualEffectView {
+    let view = NSVisualEffectView()
+    view.material = .titlebar
+    view.blendingMode = .withinWindow
+    view.state = .followsWindowActiveState
+    return view
+  }
+
+  func updateNSView(_ view: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -65,12 +65,13 @@ struct MainView: View {
 
   private var home: some View {
     VStack(spacing: 20) {
+      Spacer(minLength: 8)
       hero
       if let error = desktop.error { errorCard(error) }
-      Spacer(minLength: 12)
+      Spacer(minLength: 8)
       positionCard
     }
-    .padding(EdgeInsets(top: 26, leading: 20, bottom: 22, trailing: 20))
+    .padding(EdgeInsets(top: 20, leading: 20, bottom: 22, trailing: 20))
   }
 
   private var hero: some View {

--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -1,43 +1,76 @@
 import AppKit
 import SwiftUI
 
+@MainActor
+final class Navigator: ObservableObject {
+  enum Screen {
+    case main
+    case settings
+  }
+
+  @Published var screen = Screen.main
+}
+
 struct MainView: View {
   @ObservedObject var desktop: LiveDesktop
-  @Environment(\.openWindow) private var openWindow
+  @ObservedObject var navigator: Navigator
 
   var body: some View {
     VStack(spacing: 0) {
       header
       Divider().opacity(0.6)
-      ScrollView {
-        VStack(spacing: 20) {
-          hero
-          if let error = desktop.error { errorCard(error) }
-          positionCard
-        }
-        .padding(EdgeInsets(top: 22, leading: 20, bottom: 22, trailing: 20))
-      }
-      .background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea())
+      content
     }
-    .frame(width: 420, height: 470)
+    .frame(width: 460, height: 580)
   }
 
   private var header: some View {
     ZStack {
-      Text("Hinge")
+      Text(navigator.screen == .main ? "Hinge" : "Settings")
         .font(.system(size: 13, weight: .semibold))
       HStack(spacing: 0) {
-        Spacer(minLength: 0)
-        HeaderButton(symbol: "gearshape.fill", help: "Settings") {
-          openWindow(id: "settings")
-          NSApp.activate(ignoringOtherApps: true)
+        if navigator.screen == .settings {
+          HeaderButton(symbol: "chevron.left", help: "Back") { navigator.screen = .main }
+            .keyboardShortcut(.escape, modifiers: [])
         }
-        .keyboardShortcut(",", modifiers: .command)
+        Spacer(minLength: 0)
+        if navigator.screen == .main {
+          HeaderButton(symbol: "gearshape.fill", help: "Settings") {
+            navigator.screen = .settings
+          }
+          .keyboardShortcut(",", modifiers: .command)
+        }
       }
+      .padding(.leading, 76)
       .padding(.trailing, 12)
     }
     .frame(height: 40)
     .background(HeaderMaterial().ignoresSafeArea())
+  }
+
+  private var content: some View {
+    ZStack {
+      switch navigator.screen {
+      case .main:
+        home
+          .transition(.move(edge: .leading).combined(with: .opacity))
+      case .settings:
+        SettingsView(desktop: desktop)
+          .transition(.move(edge: .trailing).combined(with: .opacity))
+      }
+    }
+    .animation(.easeInOut(duration: 0.22), value: navigator.screen)
+    .background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea())
+  }
+
+  private var home: some View {
+    VStack(spacing: 20) {
+      hero
+      if let error = desktop.error { errorCard(error) }
+      Spacer(minLength: 12)
+      positionCard
+    }
+    .padding(EdgeInsets(top: 26, leading: 20, bottom: 22, trailing: 20))
   }
 
   private var hero: some View {

--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -81,7 +81,10 @@ struct MainView: View {
   }
 
   private var positionCard: some View {
-    SettingsGroup(title: "Open position") {
+    SettingsGroup(
+      title: "Open position",
+      footnote: "Starts at 100°. Set your comfortable open position once, and Hinge remembers it."
+    ) {
       SettingsRow(
         "angle", tint: .indigo, title: "Open position", subtitle: "\(Int(desktop.openAngle))°"
       ) {

--- a/Sources/SettingsChrome.swift
+++ b/Sources/SettingsChrome.swift
@@ -134,3 +134,11 @@ struct SidebarMaterial: NSViewRepresentable {
 
   func updateNSView(_ view: NSVisualEffectView, context: Context) {}
 }
+
+func openScreenRecordingSettings() {
+  guard
+    let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+  else { return }
+  NSWorkspace.shared.open(url)
+}

--- a/Sources/SettingsChrome.swift
+++ b/Sources/SettingsChrome.swift
@@ -123,18 +123,6 @@ struct SettingsPage<Content: View>: View {
   }
 }
 
-struct SidebarMaterial: NSViewRepresentable {
-  func makeNSView(context: Context) -> NSVisualEffectView {
-    let view = NSVisualEffectView()
-    view.material = .sidebar
-    view.blendingMode = .behindWindow
-    view.state = .followsWindowActiveState
-    return view
-  }
-
-  func updateNSView(_ view: NSVisualEffectView, context: Context) {}
-}
-
 func openScreenRecordingSettings() {
   guard
     let url = URL(

--- a/Sources/SettingsChrome.swift
+++ b/Sources/SettingsChrome.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+
+enum SettingsMetrics {
+  static let groupSpacing: CGFloat = 22
+  static let cardCorner: CGFloat = 12
+  static let rowPaddingH: CGFloat = 14
+  static let rowPaddingV: CGFloat = 11
+  static let iconSize: CGFloat = 26
+  static let iconCorner: CGFloat = 6.5
+  static let dividerInset: CGFloat = rowPaddingH + iconSize + 11
+}
+
+struct SettingsGroup<Content: View>: View {
+  let title: String
+  var footnote: String?
+  @ViewBuilder let content: Content
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 7) {
+      Text(title)
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .padding(.leading, 2)
+      VStack(spacing: 0) { content }
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsMetrics.cardCorner, style: .continuous))
+        .overlay(
+          RoundedRectangle(cornerRadius: SettingsMetrics.cardCorner, style: .continuous)
+            .strokeBorder(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+      if let footnote {
+        Text(footnote)
+          .font(.system(size: 11))
+          .foregroundStyle(.tertiary)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.leading, 2)
+          .padding(.top, 1)
+      }
+    }
+  }
+}
+
+struct SettingsIcon: View {
+  let symbol: String
+  var tint = Color.accentColor
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: SettingsMetrics.iconCorner, style: .continuous)
+      .fill(tint.gradient)
+      .frame(width: SettingsMetrics.iconSize, height: SettingsMetrics.iconSize)
+      .overlay(
+        Image(systemName: symbol)
+          .font(.system(size: SettingsMetrics.iconSize * 0.55, weight: .semibold))
+          .foregroundStyle(.white)
+      )
+  }
+}
+
+struct SettingsRow<Leading: View, Trailing: View>: View {
+  let title: String
+  var subtitle: String?
+  @ViewBuilder var leading: Leading
+  @ViewBuilder var trailing: Trailing
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 11) {
+      leading
+        .frame(width: SettingsMetrics.iconSize, height: SettingsMetrics.iconSize)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.system(size: 13))
+          .fixedSize(horizontal: false, vertical: true)
+        if let subtitle {
+          Text(subtitle)
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      Spacer(minLength: 10)
+      trailing
+    }
+    .padding(.horizontal, SettingsMetrics.rowPaddingH)
+    .padding(.vertical, SettingsMetrics.rowPaddingV)
+  }
+}
+
+extension SettingsRow where Leading == SettingsIcon {
+  init(
+    _ symbol: String, tint: Color = .accentColor, title: String, subtitle: String? = nil,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.init(
+      title: title, subtitle: subtitle, leading: { SettingsIcon(symbol: symbol, tint: tint) },
+      trailing: trailing)
+  }
+}
+
+struct SettingsDivider: View {
+  var inset = SettingsMetrics.dividerInset
+
+  var body: some View {
+    Divider()
+      .opacity(0.5)
+      .padding(.leading, inset)
+  }
+}
+
+struct SettingsPage<Content: View>: View {
+  @ViewBuilder let content: Content
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: SettingsMetrics.groupSpacing) {
+        content
+      }
+      .padding(EdgeInsets(top: 4, leading: 20, bottom: 24, trailing: 20))
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .contentMargins(.top, 8, for: .scrollContent)
+    .background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea())
+  }
+}
+
+struct SidebarMaterial: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSVisualEffectView {
+    let view = NSVisualEffectView()
+    view.material = .sidebar
+    view.blendingMode = .behindWindow
+    view.state = .followsWindowActiveState
+    return view
+  }
+
+  func updateNSView(_ view: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3,124 +3,235 @@ import SwiftUI
 
 struct SettingsView: View {
   @ObservedObject var desktop: LiveDesktop
+  @State private var page = Page.effect
+
+  enum Page: String, CaseIterable, Identifiable {
+    case effect
+    case general
+
+    var id: String { rawValue }
+
+    var title: String {
+      switch self {
+      case .effect: "Effect"
+      case .general: "General"
+      }
+    }
+
+    var symbol: String {
+      switch self {
+      case .effect: "laptopcomputer"
+      case .general: "gearshape.fill"
+      }
+    }
+
+    var tint: Color {
+      switch self {
+      case .effect: .blue
+      case .general: .gray
+      }
+    }
+  }
+
+  var body: some View {
+    HStack(spacing: 0) {
+      sidebar
+        .frame(width: 180)
+        .background(SidebarMaterial().ignoresSafeArea())
+      Divider().ignoresSafeArea()
+      switch page {
+      case .effect: EffectPage(desktop: desktop)
+      case .general: GeneralPage(desktop: desktop)
+      }
+    }
+    .frame(width: 620, height: 460)
+  }
+
+  private var sidebar: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Color.clear.frame(height: 10)
+      ForEach(Page.allCases) { item in
+        Button {
+          page = item
+        } label: {
+          HStack(spacing: 10) {
+            SettingsIcon(symbol: item.symbol, tint: item.tint)
+            Text(item.title)
+              .font(.system(size: 13))
+              .foregroundStyle(page == item ? Color.white : Color.primary)
+            Spacer(minLength: 0)
+          }
+          .padding(.horizontal, 8)
+          .padding(.vertical, 6)
+          .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+              .fill(page == item ? Color.accentColor : .clear)
+          )
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 9)
+  }
+}
+
+private struct EffectPage: View {
+  @ObservedObject var desktop: LiveDesktop
+
+  var body: some View {
+    SettingsPage {
+      SettingsGroup(title: "Hinge") {
+        SettingsRow(
+          "power", tint: desktop.isActive ? .green : .gray, title: "Follow the lid",
+          subtitle: status
+        ) {
+          Toggle(
+            "Follow the lid",
+            isOn: Binding(
+              get: { desktop.isActive || desktop.isStarting },
+              set: { enabled in
+                if enabled { Task { await desktop.start() } } else { desktop.stop() }
+              })
+          )
+          .toggleStyle(.switch)
+          .controlSize(.small)
+          .labelsHidden()
+          .disabled(desktop.isStarting)
+        }
+        if let error = desktop.error {
+          SettingsDivider()
+          SettingsRow("exclamationmark.triangle.fill", tint: .orange, title: error) {
+            if desktop.needsPermission {
+              Button("Open Settings", action: openScreenRecordingSettings)
+                .controlSize(.small)
+            }
+          }
+        }
+      }
+      SettingsGroup(title: "Look") {
+        SettingsRow(
+          "slider.horizontal.3", tint: .orange, title: "Effect strength",
+          subtitle: "\(Int(desktop.effectStrength * 100))%"
+        ) {
+          HStack(spacing: 8) {
+            Slider(
+              value: Binding(
+                get: { desktop.effectStrength },
+                set: { desktop.setEffectStrength($0) }),
+              in: 0.25...1, step: 0.05
+            )
+            .frame(width: 120)
+            .accessibilityLabel("Effect strength")
+            .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
+            Button("Default") { desktop.setEffectStrength(1) }
+              .controlSize(.small)
+              .fixedSize()
+              .disabled(desktop.effectStrength == 1)
+              .help("Reset effect strength to 100%")
+              .accessibilityLabel("Reset effect strength to default")
+          }
+        }
+      }
+      SettingsGroup(
+        title: "Open position",
+        footnote:
+          "Starts at 100°. Set your comfortable open position once, and Hinge remembers it."
+      ) {
+        SettingsRow(
+          "angle", tint: .indigo, title: "Open position", subtitle: "\(Int(desktop.openAngle))°"
+        ) {
+          Button("Set open position") { desktop.setOpenPosition() }
+            .controlSize(.small)
+            .disabled(!desktop.sensorAvailable || desktop.isStarting)
+        }
+      }
+    }
+  }
+
+  private var status: String {
+    if desktop.isStarting { return "Starting…" }
+    return desktop.isActive ? "On. Your desktop bends as the lid closes." : "Off"
+  }
+}
+
+private struct GeneralPage: View {
+  @ObservedObject var desktop: LiveDesktop
   @State private var loginItemStatus = SMAppService.mainApp.status
   @State private var loginItemError: String?
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 24) {
-      HStack(spacing: 14) {
-        Image(systemName: "laptopcomputer")
-          .font(.system(size: 29, weight: .light))
-          .foregroundStyle(.blue)
-          .frame(width: 54, height: 54)
-          .background(.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 15))
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Hinge").font(.system(size: 26, weight: .semibold))
-          Text("Your desktop follows your lid.")
-            .font(.system(size: 12))
-            .foregroundStyle(.secondary)
-        }
-      }
-      VStack(spacing: 18) {
-        Toggle(
-          isOn: Binding(
-            get: { desktop.isActive || desktop.isStarting },
-            set: { enabled in
-              if enabled { Task { await desktop.start() } } else { desktop.stop() }
-            })
+    SettingsPage {
+      SettingsGroup(title: "Controls") {
+        SettingsRow(
+          "power", tint: .blue, title: "Launch at login", subtitle: loginItemError ?? loginItemNote
         ) {
-          HStack(spacing: 7) {
-            Circle().fill(desktop.isActive ? Color.green : Color.secondary.opacity(0.45))
-              .frame(width: 6, height: 6)
-            Text(desktop.isStarting ? "Starting…" : desktop.isActive ? "On" : "Off")
-              .fontWeight(.medium)
+          if loginItemStatus == .requiresApproval {
+            Button("Open Login Items") { SMAppService.openSystemSettingsLoginItems() }
+              .controlSize(.small)
           }
+          Toggle("Launch at login", isOn: launchAtLogin)
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .labelsHidden()
         }
-        .toggleStyle(.switch)
-        .disabled(desktop.isStarting)
-        Divider()
-        HStack {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Effect strength").fontWeight(.medium)
-            Text("\(Int(desktop.effectStrength * 100))%")
-              .foregroundStyle(.secondary)
-              .monospacedDigit()
-          }
-          Spacer()
-          Slider(
-            value: Binding(
-              get: { desktop.effectStrength },
-              set: { desktop.setEffectStrength($0) }),
-            in: 0.25...1, step: 0.05
-          )
-          .frame(width: 100)
-          .accessibilityLabel("Effect strength")
-          .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
-          Button("Default") { desktop.setEffectStrength(1) }
-            .disabled(desktop.effectStrength == 1)
-            .help("Reset effect strength to 100%")
-            .accessibilityLabel("Reset effect strength to default")
-        }
-        Divider()
-        HStack {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Open position").fontWeight(.medium)
-            Text("\(Int(desktop.openAngle))°")
-              .foregroundStyle(.secondary)
-              .monospacedDigit()
-          }
-          Spacer()
-          Button("Set open position") { desktop.setOpenPosition() }
-            .disabled(!desktop.sensorAvailable || desktop.isStarting)
-        }
-        Divider()
-        Toggle("Launch at login", isOn: launchAtLogin)
-          .toggleStyle(.switch)
-        if loginItemStatus == .requiresApproval {
-          Button("Approval required in Login Items") {
-            SMAppService.openSystemSettingsLoginItems()
-          }
-          .buttonStyle(.link)
+        SettingsDivider()
+        SettingsRow("keyboard", tint: .gray, title: "Turn Hinge on or off") {
+          Text("⌃⌥H")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 5))
         }
       }
-      .font(.system(size: 12))
-      if let loginItemError {
-        Text(loginItemError)
-          .font(.system(size: 12))
-          .foregroundStyle(.orange)
-          .fixedSize(horizontal: false, vertical: true)
+      SettingsGroup(
+        title: "Status",
+        footnote:
+          "Hinge reads your display only to draw the fold. Frames stay in memory on your Mac."
+      ) {
+        let allowed = CGPreflightScreenCaptureAccess()
+        SettingsRow(
+          "rectangle.dashed.badge.record", tint: .red, title: "Screen Recording",
+          subtitle: allowed ? "Allowed" : "Needed to show your live desktop"
+        ) {
+          if allowed {
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+          } else {
+            Button("Open Settings", action: openScreenRecordingSettings)
+              .controlSize(.small)
+          }
+        }
+        SettingsDivider()
+        SettingsRow(
+          "laptopcomputer", tint: .teal, title: "Lid angle sensor",
+          subtitle: desktop.sensorAvailable ? "Connected" : "Not connected"
+        ) {
+          Circle()
+            .fill(desktop.sensorAvailable ? Color.green : Color.orange)
+            .frame(width: 8, height: 8)
+        }
       }
-      if let error = desktop.error {
-        VStack(alignment: .leading, spacing: 8) {
-          Text(error).foregroundStyle(.orange)
-          if desktop.needsPermission {
-            Button("Open Screen Recording settings") {
-              NSWorkspace.shared.open(
-                URL(
-                  string:
-                    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
-              )
+      SettingsGroup(title: "About") {
+        SettingsRow(
+          title: "Hinge \(version)", subtitle: "Your desktop follows your lid.",
+          leading: { Image(nsImage: NSApp.applicationIconImage).resizable() },
+          trailing: {
+            if let project = URL(string: "https://github.com/Noveum/hinge") {
+              Link("GitHub", destination: project).font(.system(size: 12))
             }
-            .buttonStyle(.link)
-          }
-        }
-        .font(.system(size: 12))
-        .fixedSize(horizontal: false, vertical: true)
-      } else {
-        Text("Starts at 100°. Set your comfortable open position once, and Hinge remembers it.")
-          .font(.system(size: 12))
-          .foregroundStyle(.secondary)
-          .fixedSize(horizontal: false, vertical: true)
+          })
       }
     }
-    .padding(28)
-    .padding(.top, 12)
-    .frame(width: 376)
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
-    {
-      _ in
+    { _ in
       loginItemStatus = SMAppService.mainApp.status
     }
+  }
+
+  private var loginItemNote: String? {
+    loginItemStatus == .requiresApproval ? "Allow Hinge in Login Items to finish." : nil
   }
 
   private var launchAtLogin: Binding<Bool> {
@@ -144,4 +255,16 @@ struct SettingsView: View {
     }
     loginItemStatus = SMAppService.mainApp.status
   }
+
+  private var version: String {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+  }
+}
+
+private func openScreenRecordingSettings() {
+  guard
+    let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+  else { return }
+  NSWorkspace.shared.open(url)
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -82,34 +82,6 @@ private struct EffectPage: View {
 
   var body: some View {
     SettingsPage {
-      SettingsGroup(title: "Hinge") {
-        SettingsRow(
-          "power", tint: desktop.isActive ? .green : .gray, title: "Follow the lid",
-          subtitle: status
-        ) {
-          Toggle(
-            "Follow the lid",
-            isOn: Binding(
-              get: { desktop.isActive || desktop.isStarting },
-              set: { enabled in
-                if enabled { Task { await desktop.start() } } else { desktop.stop() }
-              })
-          )
-          .toggleStyle(.switch)
-          .controlSize(.small)
-          .labelsHidden()
-          .disabled(desktop.isStarting)
-        }
-        if let error = desktop.error {
-          SettingsDivider()
-          SettingsRow("exclamationmark.triangle.fill", tint: .orange, title: error) {
-            if desktop.needsPermission {
-              Button("Open Settings", action: openScreenRecordingSettings)
-                .controlSize(.small)
-            }
-          }
-        }
-      }
       SettingsGroup(title: "Look") {
         SettingsRow(
           "slider.horizontal.3", tint: .orange, title: "Effect strength",
@@ -132,19 +104,6 @@ private struct EffectPage: View {
               .help("Reset effect strength to 100%")
               .accessibilityLabel("Reset effect strength to default")
           }
-        }
-      }
-      SettingsGroup(
-        title: "Open position",
-        footnote:
-          "Starts at 100°. Set your comfortable open position once, and Hinge remembers it."
-      ) {
-        SettingsRow(
-          "angle", tint: .indigo, title: "Open position", subtitle: "\(Int(desktop.openAngle))°"
-        ) {
-          Button("Set open position") { desktop.setOpenPosition() }
-            .controlSize(.small)
-            .disabled(!desktop.sensorAvailable || desktop.isStarting)
         }
       }
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3,189 +3,115 @@ import SwiftUI
 
 struct SettingsView: View {
   @ObservedObject var desktop: LiveDesktop
-  @State private var page = Page.effect
-
-  enum Page: String, CaseIterable, Identifiable {
-    case effect
-    case general
-
-    var id: String { rawValue }
-
-    var title: String {
-      switch self {
-      case .effect: "Effect"
-      case .general: "General"
-      }
-    }
-
-    var symbol: String {
-      switch self {
-      case .effect: "laptopcomputer"
-      case .general: "gearshape.fill"
-      }
-    }
-
-    var tint: Color {
-      switch self {
-      case .effect: .blue
-      case .general: .gray
-      }
-    }
-  }
-
-  var body: some View {
-    HStack(spacing: 0) {
-      sidebar
-        .frame(width: 180)
-        .background(SidebarMaterial().ignoresSafeArea())
-      Divider().ignoresSafeArea()
-      switch page {
-      case .effect: EffectPage(desktop: desktop)
-      case .general: GeneralPage(desktop: desktop)
-      }
-    }
-    .frame(width: 620, height: 460)
-  }
-
-  private var sidebar: some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Color.clear.frame(height: 10)
-      ForEach(Page.allCases) { item in
-        Button {
-          page = item
-        } label: {
-          HStack(spacing: 10) {
-            SettingsIcon(symbol: item.symbol, tint: item.tint)
-            Text(item.title)
-              .font(.system(size: 13))
-              .foregroundStyle(page == item ? Color.white : Color.primary)
-            Spacer(minLength: 0)
-          }
-          .padding(.horizontal, 8)
-          .padding(.vertical, 6)
-          .background(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-              .fill(page == item ? Color.accentColor : .clear)
-          )
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-      }
-      Spacer(minLength: 0)
-    }
-    .padding(.horizontal, 9)
-  }
-}
-
-private struct EffectPage: View {
-  @ObservedObject var desktop: LiveDesktop
-
-  var body: some View {
-    SettingsPage {
-      SettingsGroup(title: "Look") {
-        SettingsRow(
-          "slider.horizontal.3", tint: .orange, title: "Effect strength",
-          subtitle: "\(Int(desktop.effectStrength * 100))%"
-        ) {
-          HStack(spacing: 8) {
-            Slider(
-              value: Binding(
-                get: { desktop.effectStrength },
-                set: { desktop.setEffectStrength($0) }),
-              in: 0.25...1, step: 0.05
-            )
-            .frame(width: 120)
-            .accessibilityLabel("Effect strength")
-            .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
-            Button("Default") { desktop.setEffectStrength(1) }
-              .controlSize(.small)
-              .fixedSize()
-              .disabled(desktop.effectStrength == 1)
-              .help("Reset effect strength to 100%")
-              .accessibilityLabel("Reset effect strength to default")
-          }
-        }
-      }
-    }
-  }
-
-  private var status: String {
-    if desktop.isStarting { return "Starting…" }
-    return desktop.isActive ? "On. Your desktop bends as the lid closes." : "Off"
-  }
-}
-
-private struct GeneralPage: View {
-  @ObservedObject var desktop: LiveDesktop
   @State private var loginItemStatus = SMAppService.mainApp.status
   @State private var loginItemError: String?
 
   var body: some View {
     SettingsPage {
-      SettingsGroup(title: "Controls") {
-        SettingsRow(
-          "power", tint: .blue, title: "Launch at login", subtitle: loginItemError ?? loginItemNote
-        ) {
-          if loginItemStatus == .requiresApproval {
-            Button("Open Login Items") { SMAppService.openSystemSettingsLoginItems() }
-              .controlSize(.small)
-          }
-          Toggle("Launch at login", isOn: launchAtLogin)
-            .toggleStyle(.switch)
-            .controlSize(.small)
-            .labelsHidden()
-        }
-        SettingsDivider()
-        SettingsRow("keyboard", tint: .gray, title: "Turn Hinge on or off") {
-          Text("⌃⌥H")
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 5))
-        }
-      }
-      SettingsGroup(
-        title: "Status",
-        footnote:
-          "Hinge reads your display only to draw the fold. Frames stay in memory on your Mac."
-      ) {
-        let allowed = CGPreflightScreenCaptureAccess()
-        SettingsRow(
-          "rectangle.dashed.badge.record", tint: .red, title: "Screen Recording",
-          subtitle: allowed ? "Allowed" : "Needed to show your live desktop"
-        ) {
-          if allowed {
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-          } else {
-            Button("Open Settings", action: openScreenRecordingSettings)
-              .controlSize(.small)
-          }
-        }
-        SettingsDivider()
-        SettingsRow(
-          "laptopcomputer", tint: .teal, title: "Lid angle sensor",
-          subtitle: desktop.sensorAvailable ? "Connected" : "Not connected"
-        ) {
-          Circle()
-            .fill(desktop.sensorAvailable ? Color.green : Color.orange)
-            .frame(width: 8, height: 8)
-        }
-      }
-      SettingsGroup(title: "About") {
-        SettingsRow(
-          title: "Hinge \(version)", subtitle: "Your desktop follows your lid.",
-          leading: { Image(nsImage: NSApp.applicationIconImage).resizable() },
-          trailing: {
-            if let project = URL(string: "https://github.com/Noveum/hinge") {
-              Link("GitHub", destination: project).font(.system(size: 12))
-            }
-          })
-      }
+      look
+      controls
+      status
+      about
     }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
     { _ in
       loginItemStatus = SMAppService.mainApp.status
+    }
+  }
+
+  private var look: some View {
+    SettingsGroup(title: "Look") {
+      SettingsRow(
+        "slider.horizontal.3", tint: .orange, title: "Effect strength",
+        subtitle: "\(Int(desktop.effectStrength * 100))%"
+      ) {
+        HStack(spacing: 8) {
+          Slider(
+            value: Binding(
+              get: { desktop.effectStrength },
+              set: { desktop.setEffectStrength($0) }),
+            in: 0.25...1, step: 0.05
+          )
+          .frame(width: 110)
+          .accessibilityLabel("Effect strength")
+          .accessibilityValue("\(Int(desktop.effectStrength * 100)) percent")
+          Button("Default") { desktop.setEffectStrength(1) }
+            .controlSize(.small)
+            .fixedSize()
+            .disabled(desktop.effectStrength == 1)
+            .help("Reset effect strength to 100%")
+            .accessibilityLabel("Reset effect strength to default")
+        }
+      }
+    }
+  }
+
+  private var controls: some View {
+    SettingsGroup(title: "Controls") {
+      SettingsRow(
+        "power", tint: .blue, title: "Launch at login", subtitle: loginItemError ?? loginItemNote
+      ) {
+        if loginItemStatus == .requiresApproval {
+          Button("Open Login Items") { SMAppService.openSystemSettingsLoginItems() }
+            .controlSize(.small)
+        }
+        Toggle("Launch at login", isOn: launchAtLogin)
+          .toggleStyle(.switch)
+          .controlSize(.small)
+          .labelsHidden()
+      }
+      SettingsDivider()
+      SettingsRow("keyboard", tint: .gray, title: "Turn Hinge on or off") {
+        Text("⌃⌥H")
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 7)
+          .padding(.vertical, 3)
+          .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 5))
+      }
+    }
+  }
+
+  private var status: some View {
+    SettingsGroup(
+      title: "Status",
+      footnote:
+        "Hinge reads your display only to draw the fold. Frames stay in memory on your Mac."
+    ) {
+      let allowed = CGPreflightScreenCaptureAccess()
+      SettingsRow(
+        "rectangle.dashed.badge.record", tint: .red, title: "Screen Recording",
+        subtitle: allowed ? "Allowed" : "Needed to show your live desktop"
+      ) {
+        if allowed {
+          Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+        } else {
+          Button("Open Settings", action: openScreenRecordingSettings)
+            .controlSize(.small)
+        }
+      }
+      SettingsDivider()
+      SettingsRow(
+        "laptopcomputer", tint: .teal, title: "Lid angle sensor",
+        subtitle: desktop.sensorAvailable ? "Connected" : "Not connected"
+      ) {
+        Circle()
+          .fill(desktop.sensorAvailable ? Color.green : Color.orange)
+          .frame(width: 8, height: 8)
+      }
+    }
+  }
+
+  private var about: some View {
+    SettingsGroup(title: "About") {
+      SettingsRow(
+        title: "Hinge \(version)", subtitle: "Your desktop follows your lid.",
+        leading: { Image(nsImage: NSApp.applicationIconImage).resizable() },
+        trailing: {
+          if let project = URL(string: "https://github.com/Noveum/hinge") {
+            Link("GitHub", destination: project).font(.system(size: 12))
+          }
+        })
     }
   }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -260,11 +260,3 @@ private struct GeneralPage: View {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
   }
 }
-
-private func openScreenRecordingSettings() {
-  guard
-    let url = URL(
-      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
-  else { return }
-  NSWorkspace.shared.open(url)
-}


### PR DESCRIPTION
Settings is one fixed column that now stacks the switch, effect strength (#10), open position, and Launch at Login (#8), and each new option squeezes into the same stack. This proposes a sidebar with Effect and General pages built from a few shared pieces in `SettingsChrome.swift`: titled card groups with an optional footnote, rows with a tinted symbol, a subtitle, and a trailing control, and an inset divider.

![Effect and General pages in light and dark](https://raw.githubusercontent.com/ReffWu/hinge/ef28624cb522dc55ed1809612d43d12974fb3e2d/settings-light-dark.png)

- Effect: the switch with its status, errors with their fix inline, effect strength, and the open position.
- General: Launch at Login and the Control-Option-H shortcut (#12), Screen Recording and lid sensor status, and an About row.
- A new option is one row in a group; a new page is one case in `Page`.
- The window keeps the hidden title bar; the sidebar material and page background extend beneath it, so there is no bare band.

<details><summary>Error state</summary>

![Screen Recording error with its fix](https://raw.githubusercontent.com/ReffWu/hinge/ef28624cb522dc55ed1809612d43d12974fb3e2d/settings-error.png)

</details>

Validated with `swift-format lint --strict Sources/*.swift`, `python3 scripts/check.py policy`, `make build`, and `xcodebuild -project Hinge.xcodeproj -scheme Hinge build`. `SettingsChrome.swift` is added to the Xcode project.

Happy to adjust the layout or copy. Other open PRs add a Sides option and a waiting status to the current Settings; I'll rebase whichever lands first into these groups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned main window with animated navigation between the primary screen and Settings.
  - Added keyboard shortcuts for opening Settings and toggling Hinge.
  - Added a structured Settings experience with sections for appearance, controls, status, and app information.
  - Added links for managing Screen Recording permissions and Login Items.
  - Added status indicators for permissions and lid angle sensor connectivity.
- **Changes**
  - Consolidated Settings into the main Hinge window.
  - Replaced in-app toggle and position controls with shortcut guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->