### PR TITLE
Put the window header in the title bar row

### DIFF
--- a/Sources/MainView.swift
+++ b/Sources/MainView.swift
@@ -16,10 +16,14 @@ struct MainView: View {
   @ObservedObject var navigator: Navigator
 
   var body: some View {
-    VStack(spacing: 0) {
-      header
-      Divider().opacity(0.6)
-      content
+    GeometryReader { proxy in
+      VStack(spacing: 0) {
+        header
+          .frame(height: proxy.safeAreaInsets.top)
+        Divider().opacity(0.6)
+        content
+      }
+      .ignoresSafeArea(.container, edges: .top)
     }
     .frame(width: 460, height: 580)
   }
@@ -44,7 +48,7 @@ struct MainView: View {
       .padding(.leading, 76)
       .padding(.trailing, 12)
     }
-    .frame(height: 40)
+    .frame(maxHeight: .infinity)
     .background(HeaderMaterial().ignoresSafeArea())
   }
 


### PR DESCRIPTION
Follow-up to #19. The window uses a hidden title bar, but the header was laid out below it. The window opened with a 32 point strip that held only the window buttons, then a 40 point header whose back button kept the 76 point inset meant for clearing those buttons one row higher. The back button looked detached, and the top of the window carried about 72 points of chrome.

The header now fills the title bar area, sized from the window's safe area inset instead of a fixed height, so it follows whatever title bar height the running macOS uses. The back button sits right after the window buttons, and the title and gear line up with them. Clicks still reach the header buttons. Nothing else in the layout changes; the content gains the 40 points the extra band used.

![Settings before and after, light and dark](https://raw.githubusercontent.com/ReffWu/hinge/3b253bf398dd95aa0babb44af232cedb9e568ae2/header-before-after.png)

Validated with `swift-format lint --strict Sources/*.swift`, `python3 scripts/check.py policy`, and `make build`, plus a hit test on the back button and gear in the built window.
